### PR TITLE
Prevent NullPointerException in data channel observer

### DIFF
--- a/src/main/java/org/saltyrtc/tasks/webrtc/WebRTCTask.java
+++ b/src/main/java/org/saltyrtc/tasks/webrtc/WebRTCTask.java
@@ -424,7 +424,7 @@ public class WebRTCTask implements Task {
                 // the SecureDataChannel instance may be null.
                 // In that case, ignore the state change.
                 if (sdc == null) {
-                    logger.warn("DataChannel: onStateChange, but data channel is null");
+                    logger.debug("DataChannel: onStateChange, but data channel is null");
                     return;
                 }
 

--- a/src/main/java/org/saltyrtc/tasks/webrtc/WebRTCTask.java
+++ b/src/main/java/org/saltyrtc/tasks/webrtc/WebRTCTask.java
@@ -424,7 +424,7 @@ public class WebRTCTask implements Task {
                 // the SecureDataChannel instance may be null.
                 // In that case, ignore the state change.
                 if (sdc == null) {
-                    logger.debug("DataChannel: onStateChange, but data channel is null");
+                    logger.warn("DataChannel: onStateChange, but data channel is null");
                     return;
                 }
 
@@ -507,6 +507,7 @@ public class WebRTCTask implements Task {
         if (this.sdc != null) {
             this.getLogger().debug("Closing signaling data channel: " + CloseCode.explain(reason));
             this.sdc.close();
+            this.sdc.unregisterObserver();
             this.sdc.dispose();
             this.sdc = null;
             this.signaling.setState(SignalingState.CLOSED);

--- a/src/main/java/org/saltyrtc/tasks/webrtc/WebRTCTask.java
+++ b/src/main/java/org/saltyrtc/tasks/webrtc/WebRTCTask.java
@@ -54,7 +54,6 @@ import java.util.Set;
  */
 @SuppressWarnings("unused")
 public class WebRTCTask implements Task {
-
     // Constants as defined by the specification
     private static final String PROTOCOL_NAME = "v0.webrtc.tasks.saltyrtc.org";
     private static final Integer DEFAULT_MAX_PACKET_SIZE = 16384;
@@ -421,6 +420,14 @@ public class WebRTCTask implements Task {
                 final SignalingInterface signaling = WebRTCTask.this.signaling;
                 final SecureDataChannel sdc = WebRTCTask.this.sdc;
 
+                // When the close() method is called before this state change callback is triggered,
+                // the SecureDataChannel instance may be null.
+                // In that case, ignore the state change.
+                if (sdc == null) {
+                    logger.warn("DataChannel: onStateChange, but data channel is null");
+                    return;
+                }
+
                 logger.info("DataChannel: State changed to " + sdc.state());
                 switch (sdc.state()) {
                     case CONNECTING:
@@ -502,6 +509,7 @@ public class WebRTCTask implements Task {
             this.sdc.close();
             this.sdc.dispose();
             this.sdc = null;
+            this.signaling.setState(SignalingState.CLOSED);
         }
     }
 }


### PR DESCRIPTION
@lgrahl this should fix a NPE in Threema.

To avoid a state not being updated when the DC is closed, I added an explicit state transition in the `close` method.